### PR TITLE
C support : type qualifiers

### DIFF
--- a/asdl/lang/cpp/cpp_asdl.simplified.txt
+++ b/asdl/lang/cpp/cpp_asdl.simplified.txt
@@ -67,6 +67,7 @@ statement = AccessSpecDecl(identifier access_spec)
       | TypeRef(identifier name)
       | UnaryOperator(constant opcode, constant postfix, statement* subnodes)
       | UsingDirectiveDecl(identifier name)
-      | VarDecl(identifier name, identifier type, identifier storage_class, identifier array, identifier init, constant implicit, constant referenced, statement* subnodes)
+      | VarDecl(identifier name, type type, identifier storage_class, identifier array, identifier init, constant implicit, constant referenced, statement* subnodes)
       | CXXStdInitializerListExpr(statement* subnodes)
 
+type = QualType(identifier type)

--- a/asdl/lang/cpp/cppastor/code_gen.py
+++ b/asdl/lang/cpp/cppastor/code_gen.py
@@ -451,6 +451,9 @@ class SourceGenerator(ExplicitNodeVisitor):
     def visit_TypeRef(self, node: tree.TypeRef):
         self.write(node.name)
 
+    def visit_QualType(self, node: tree.QualType):
+        self.write(node.type)
+
     def visit_CXXMethodDecl(self, node: tree.CXXMethodDecl):
         parameters = []
         statements = []

--- a/asdl/lang/cpp/test/qualifier.hpp
+++ b/asdl/lang/cpp/test/qualifier.hpp
@@ -1,0 +1,9 @@
+int x = 1;
+const int cx = 2;
+volatile int vx = 3;
+const volatile int vcx = 4;
+// FIXME: volatile const int vcx2 = 4;
+
+static int sx = 5;
+int * px = &sx;
+const int * cpx = &cx;

--- a/cpplang/tree.py
+++ b/cpplang/tree.py
@@ -148,6 +148,8 @@ class Type(Node):
 class BasicType(Type):
     attrs = ()
 
+class QualType(Node):
+    attrs = ("type",)
 
 class DiamondType(Type):
     attrs = ("sub_type",)


### PR DESCRIPTION
A type in C is more than just an identifier, but the json output of clang captures it as a single string. Make that explicit in the AST though, and use the correct node value instead of parsing the text again.