### PR TITLE
c++ syntax - basic exception specification support

### DIFF
--- a/asdl/lang/cpp/cpp_asdl.simplified.txt
+++ b/asdl/lang/cpp/cpp_asdl.simplified.txt
@@ -14,7 +14,7 @@ declaration = AccessSpecDecl(identifier access_spec)
             | EnumDecl(identifier? name, enum_field* fields)
             | FieldDecl(identifier name, type type, expression? init, attribute* attributes)
             | FriendDecl(identifier type)
-            | FunctionDecl(identifier name, type return_type, constant? storage, constant? variadic, constant? inline, statement? body, parameter* parameters)
+            | FunctionDecl(identifier name, type return_type, constant? storage, constant? variadic, constant? inline, exception_spec? exception, statement? body, parameter* parameters)
             | FunctionTemplateDecl(statement* subnodes)
             | NamespaceDecl(identifier name, statement* subnodes)
             | NonTypeTemplateParmDecl(identifier name, identifier type, statement* subnodes)
@@ -125,3 +125,6 @@ default_mode = Default
              | PureVirtual
 
 final = FinalAttr
+
+exception_spec = Throw(identifier* args)
+               | NoExcept(constant? repr)

--- a/asdl/lang/cpp/cppastor/code_gen.py
+++ b/asdl/lang/cpp/cppastor/code_gen.py
@@ -589,6 +589,9 @@ class SourceGenerator(ExplicitNodeVisitor):
             self.write("...")
         self.write(")")
 
+        if node.exception:
+            self.write(" ", node.exception)
+
         if node.body:
             self.write(node.body)
         else:
@@ -878,4 +881,14 @@ class SourceGenerator(ExplicitNodeVisitor):
         else:
             self.comma_list(node.args)
             self.write(markers[1])
+
+    def visit_Throw(self, node: tree.Throw):
+        self.write("throw(")
+        self.comma_list(node.args)
+        self.write(")")
+
+    def visit_NoExcept(self, node: tree.NoExcept):
+        self.write("noexcept")
+        if node.repr:
+            self.write("(", node.repr, ")")
 

--- a/asdl/lang/cpp/test/exception_spec.hpp
+++ b/asdl/lang/cpp/test/exception_spec.hpp
@@ -1,0 +1,8 @@
+void foo() throw();
+#if  __cplusplus < 201703L
+void bar() throw(int, float);
+#endif
+
+void foobar() noexcept;
+
+void foobar() noexcept(1 + 2 != 0);

--- a/cpplang/tree.py
+++ b/cpplang/tree.py
@@ -322,7 +322,14 @@ class CXXMethodDecl(Declaration):
 
 
 class FunctionDecl(Declaration):
-    attrs = ("name", "return_type", "storage", "variadic", "inline", "body", "parameters")
+    attrs = ("name", "return_type", "storage", "variadic", "inline",
+             "exception", "body", "parameters")
+
+class Throw(Node):
+    attrs = ("args",)
+
+class NoExcept(Node):
+    attrs = ("repr",)
 
 
 class ClassTemplateDecl(Declaration):


### PR DESCRIPTION
Support throw(...) even if it's deprecated as of C++17. Don't support noexcept(expression) in the most efficient way: it's difficult to reinject an expression in the type parser so rely on the expression representation as string as of now.