### PR TITLE
c syntax - Support multiple declarations in for init statement

### DIFF
--- a/asdl/lang/cpp/cpp_asdl.simplified.txt
+++ b/asdl/lang/cpp/cpp_asdl.simplified.txt
@@ -34,7 +34,7 @@ statement = BreakStmt
           | DefaultStmt(statement stmt)
           | DoStmt(expression cond, statement body)
           | ExprStmt(expression expr)
-          | ForStmt(declaration_or_expression? init, declaration_or_expression? cond, expression? inc, statement body)
+          | ForStmt(declarations_or_expression? init, declaration_or_expression? cond, expression? inc, statement body)
           | FullComment(string comment)
           | GCCAsmStmt(constant string, constrained_expression* output_operands, constrained_expression* input_operands, constant* clobbers, constant* labels)
           | GotoStmt(identifier target)
@@ -86,7 +86,9 @@ expression = ArraySubscriptExpr(expression base, expression index)
 
 parameter = ParmVarDecl(type type, identifier? name, expression? default)
 
-declaration_or_expression = DeclOrExpr(declaration* decl, expression? expr)
+declarations_or_expression = DeclsOrExpr(declaration* decls, expression? expr)
+
+declaration_or_expression = DeclOrExpr(declaration? decl, expression? expr)
 
 cxx_ctor_initializer = CXXCtorInitializer(identifier name, expression* args)
 

--- a/asdl/lang/cpp/test/for.hpp
+++ b/asdl/lang/cpp/test/for.hpp
@@ -16,6 +16,24 @@ void for_decl() {
   for(int k; int i = 0;);
 }
 
+struct s {};
+class c {};
+using u = s;
+typedef s t;
+
+void for_multi_decl() {
+  for(int i = 0, j=1;;);
+  for(int i = 0, *j;;);
+  for(const int i = 0, *j;;);
+  for(int i = 0, * const j = nullptr;;);
+  for(int i = 0, j[2] = {1,3};;);
+  for(int i = 0, (*j)(float);;);
+  for(s i, j;;);
+  for(c i, *j, k[2];;);
+  for(t i, *j, k[2];;);
+  for(u const i = {}, *j, k[2];;);
+}
+
 void for_break() {
   for(;;) break;
 }

--- a/cpplang/parser.py
+++ b/cpplang/parser.py
@@ -764,9 +764,8 @@ class Parser(object):
         cond, *subnodes = self.parse_subnodes(node)
         if node.get('hasVar'):
             assert isinstance(cond, tree.DeclStmt)
-            if len(cond.decls) != 1:
-                raise NotImplementedError()
-            cond = tree.DeclOrExpr(decl=cond.decls, expr=None)
+            decl, = cond.decls
+            cond = tree.DeclOrExpr(decl=decl, expr=None)
             subnodes = subnodes[1:]  # pop the implicit condition evaluation
         else:
             cond = tree.DeclOrExpr(decl=None, expr=cond)
@@ -807,13 +806,13 @@ class Parser(object):
         init, cond_decl, cond, inc, body = self.parse_subnodes(node, keep_empty=True)
 
         if isinstance(init, tree.Expression):
-            init = tree.DeclOrExpr(expr=init, decl=None)
+            init = tree.DeclsOrExpr(expr=init, decls=None)
         elif isinstance(init, tree.DeclStmt):
-            init = tree.DeclOrExpr(expr=None, decl=init.decls)
-
+            init = tree.DeclsOrExpr(expr=None, decls=init.decls)
         if cond_decl:
             assert isinstance(cond_decl, tree.DeclStmt)
-            cond = tree.DeclOrExpr(expr=None, decl=cond_decl.decls)
+            decl, = cond_decl.decls
+            cond = tree.DeclOrExpr(expr=None, decl=decl)
         elif cond:
             assert isinstance(cond, tree.Expression)
             cond = tree.DeclOrExpr(expr=cond, decl=None)
@@ -829,10 +828,8 @@ class Parser(object):
         assert node['kind'] == "WhileStmt"
         if node.get('hasVar'):
             var, cond, body = self.parse_subnodes(node)
-            assert isinstance(var, tree.DeclStmt), var
-            if len(var.decls) != 1:
-                raise NotImplementedError()
-            cond = tree.DeclOrExpr(decl=var.decls, expr=None)
+            decl, = var.decls
+            cond = tree.DeclOrExpr(decl=decl, expr=None)
         else:
             cond, body = self.parse_subnodes(node)
             cond =  tree.DeclOrExpr(decl=None, expr=cond)

--- a/cpplang/tree.py
+++ b/cpplang/tree.py
@@ -564,6 +564,9 @@ class ConstrainedExpression(Node):
 class CXXForRangeStmt(Statement):
     attrs = ("decl", "range", "body",)
 
+class DeclsOrExpr(Node):
+    attrs = ("decls", "expr",)
+
 class DeclOrExpr(Node):
     attrs = ("decl", "expr",)
 


### PR DESCRIPTION
That was a missing hole in the C support, I'm glad I found a fix without (too much) ugly patch.