### PR TITLE
C syntax - support atomic builtin

### DIFF
--- a/asdl/lang/cpp/cpp_asdl.simplified.txt
+++ b/asdl/lang/cpp/cpp_asdl.simplified.txt
@@ -50,6 +50,7 @@ statement = BreakStmt
           | WhileStmt(declaration_or_expression cond, statement body)
 
 expression = ArraySubscriptExpr(expression base, expression index)
+           | AtomicExpr(identifier name, expression* args)
            | BinaryOperator(constant opcode, expression lhs, expression rhs)
            | CStyleCastExpr(type type, expression expr)
            | CXXBindTemporaryExpr(expression expr)

--- a/asdl/lang/cpp/cppastor/code_gen.py
+++ b/asdl/lang/cpp/cppastor/code_gen.py
@@ -647,6 +647,11 @@ class SourceGenerator(ExplicitNodeVisitor):
     def visit_ArraySubscriptExpr(self, node: tree.ArraySubscriptExpr):
         self.write(node.base, "[", node.index, "]")
 
+    def visit_AtomicExpr(self, node: tree.AtomicExpr):
+        self.write(node.name, "(")
+        self.comma_list(node.args)
+        self.write(")")
+
     def visit_DeclStmt(self, node: tree.DeclStmt):
         # FIXME: could be improved to support multiple decl in one statement
         for decl in node.decls:

--- a/asdl/lang/cpp/test/atomic.hpp
+++ b/asdl/lang/cpp/test/atomic.hpp
@@ -1,0 +1,35 @@
+void foo(int * ptr) {
+  int val;
+  int ret;
+  int expected;
+  int desired;
+  bool test;
+
+  __atomic_load_n(ptr, __ATOMIC_SEQ_CST);
+  __atomic_load(ptr, &ret, __ATOMIC_RELAXED);
+  __atomic_store_n(ptr, 1, __ATOMIC_SEQ_CST);
+  __atomic_store(ptr, &val, __ATOMIC_SEQ_CST);
+  __atomic_exchange_n (ptr, val, __ATOMIC_CONSUME);
+  __atomic_exchange (ptr, &val, &ret, __ATOMIC_ACQUIRE);
+  __atomic_compare_exchange_n(ptr, &expected, desired, true, __ATOMIC_SEQ_CST, __ATOMIC_RELAXED);
+  __atomic_compare_exchange (ptr, &expected, &desired, false, __ATOMIC_SEQ_CST, __ATOMIC_RELAXED);
+  __atomic_add_fetch(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_sub_fetch(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_and_fetch(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_xor_fetch(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_or_fetch(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_nand_fetch(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_fetch_add(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_fetch_sub(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_fetch_and(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_fetch_xor(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_fetch_or(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_fetch_nand(ptr, val, __ATOMIC_SEQ_CST);
+  __atomic_test_and_set(ptr, __ATOMIC_SEQ_CST);
+  __atomic_clear(&test, __ATOMIC_SEQ_CST);
+  __atomic_thread_fence(__ATOMIC_SEQ_CST);
+  __atomic_signal_fence(__ATOMIC_SEQ_CST);
+  __atomic_always_lock_free(4, ptr);
+  __atomic_is_lock_free(4, ptr);
+}
+

--- a/cpplang/JSONDumpTypes.cpp
+++ b/cpplang/JSONDumpTypes.cpp
@@ -26,6 +26,13 @@
 #include "llvm/Support/raw_ostream.h"
 #include <optional>
 
+static llvm::StringRef AtomicOpToStr(clang::AtomicExpr::AtomicOp op) {
+  switch(op) {
+#define BUILTIN(ID, TYPE, ATTRS)
+#define ATOMIC_BUILTIN(ID, TYPE, ATTRS) case clang::AtomicExpr:: AO ## ID: return #ID;
+#include "clang/Basic/Builtins.def"
+  }
+}
 
 namespace clang {
 
@@ -368,6 +375,10 @@ public:
             JOS.arrayEnd();
             JOS.attributeEnd();
         }
+      }
+      else if(const auto * AE = dyn_cast<AtomicExpr>(E)) {
+        JOS.attribute("node_id", createPointerRepresentation(AE));
+        JOS.attribute("name", AtomicOpToStr(AE->getOp()));
       }
       else if(const auto * TypeidE = dyn_cast<CXXTypeidExpr>(E)) {
         if(TypeidE->isTypeOperand()) {

--- a/cpplang/parser.py
+++ b/cpplang/parser.py
@@ -1421,6 +1421,18 @@ class Parser(object):
         return tree.ArraySubscriptExpr(base=base, index=index)
 
     @parse_debug
+    def parse_AtomicExpr(self, node) -> tree.AtomicExpr:
+        assert node['kind'] == "AtomicExpr"
+        name = self.attr_informations[node['id']]['name']
+        args = self.parse_subnodes(node)
+        # for some reason, inner args are not listed in the syntactic order
+        if name.startswith("__atomic_compare_exchange"):
+            args = args[:1] + args[2:3] + args[4:] + args[1:4:2]
+        else:
+            args = args[:1] + args[2:] + args[1:2]
+        return tree.AtomicExpr(name=name, args=args)
+
+    @parse_debug
     def parse_ParenExpr(self, node) -> tree.ParenExpr:
         assert node['kind'] == "ParenExpr"
         expr, = self.parse_subnodes(node)

--- a/cpplang/tree.py
+++ b/cpplang/tree.py
@@ -689,6 +689,10 @@ class ArraySubscriptExpr(Expression):
     attrs = ("base", "index",)
 
 
+class AtomicExpr(Expression):
+    attrs = ("name", "args")
+
+
 class MethodReference(Primary):
     attrs = ("expression", "method", "type_arguments")
 


### PR DESCRIPTION
They are represented using specific nodes in Clang, and have a special argument mangling.

The attribute name is missing from the JSON dump. Retrieve it the usual way and submit a patch upstream: https://reviews.llvm.org/D158558