### PR TITLE
c support - nothrow attribute

### DIFF
--- a/asdl/lang/cpp/cpp_asdl.simplified.txt
+++ b/asdl/lang/cpp/cpp_asdl.simplified.txt
@@ -4,9 +4,9 @@ identifier, int, string, constant
 cu = TranslationUnit(statement* stmts)
 
 declaration = AccessSpecDecl(access_spec access_spec)
-            | CXXConstructorDecl(identifier name, constant? noexcept, default_mode? defaulted, statement? body, attribute* attributes, parameter* parameters, cxx_ctor_initializer* initializers)
+            | CXXConstructorDecl(identifier name, exception_spec? exception, default_mode? defaulted, statement? body, attribute* attributes, parameter* parameters, cxx_ctor_initializer* initializers)
             | CXXConversionDecl(identifier name, constant? inline, exception_spec? exception, constant? const, statement? body, attribute* attributes)
-            | CXXDestructorDecl(identifier name, constant? noexcept, constant? virtual, default_mode? defaulted, statement? body, attribute* attributes)
+            | CXXDestructorDecl(identifier name, exception_spec? exception, constant? virtual, default_mode? defaulted, statement? body, attribute* attributes)
             | CXXMethodDecl(identifier name, type return_type, constant? storage, constant? variadic, constant? inline, exception_spec? exception, constant? virtual, constant? const, default_mode? defaulted, method_attr* method_attributes, constant? ref_qualifier, statement? body, attribute* attributes, parameter* parameters)
             | CXXRecordDecl(identifier name, identifier kind, base* bases, constant complete, declaration* decls)
             | ClassTemplateDecl(statement* subnodes)
@@ -178,6 +178,7 @@ method_attr = FinalAttr
 
 exception_spec = Throw(identifier* args)
                | NoExcept(constant? repr)
+               | NoThrow
 
 exception_handler = CXXCatchStmt(declaration? decl, statement body)
 

--- a/asdl/lang/cpp/cppastor/code_gen.py
+++ b/asdl/lang/cpp/cppastor/code_gen.py
@@ -1095,6 +1095,9 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.comma_list(node.args)
         self.write(")")
 
+    def visit_NoThrow(self, node: tree.Throw):
+        self.write("__attribute__((nothrow))")
+
     def visit_NoExcept(self, node: tree.NoExcept):
         self.write("noexcept")
         if node.repr:

--- a/asdl/lang/cpp/test/attribute.hpp
+++ b/asdl/lang/cpp/test/attribute.hpp
@@ -115,3 +115,5 @@ void* f33 (void*) __attribute__ ((nonnull));
 void* f34 (void*) __attribute__ ((nonnull(1)));
 
 void* f35 (void*) __attribute__ ((noreturn));
+
+void* f36 (void*) __attribute__ ((nothrow));

--- a/cpplang/JSONDumpTypes.cpp
+++ b/cpplang/JSONDumpTypes.cpp
@@ -99,6 +99,9 @@ static llvm::json::Object fullType(const ASTContext &Ctx, const Type * Ty) {
             ExceptionSpec["inner"] = llvm::json::Value(std::move(Inner));
           }
           break;
+        case ExceptionSpecificationType::EST_NoThrow:
+          ExceptionSpec["isNoThrow"] = true;
+          break;
         case ExceptionSpecificationType::EST_NoexceptFalse:
         case ExceptionSpecificationType::EST_NoexceptTrue:
         case ExceptionSpecificationType::EST_DependentNoexcept:

--- a/cpplang/tree.py
+++ b/cpplang/tree.py
@@ -259,7 +259,7 @@ class RecordDecl(TypeDeclaration):
 
 
 class CXXConstructorDecl(Declaration):
-    attrs = ("name", "noexcept", "defaulted", "body", "attributes", "parameters", "initializers",)
+    attrs = ("name", "exception", "defaulted", "body", "attributes", "parameters", "initializers",)
 
 
 class CXXCtorInitializer(Node):
@@ -267,7 +267,7 @@ class CXXCtorInitializer(Node):
 
 
 class CXXDestructorDecl(Declaration):
-    attrs = ("name", "noexcept", "virtual", "defaulted", "body", "attributes", )
+    attrs = ("name", "exception", "virtual", "defaulted", "body", "attributes", )
 
 
 class AccessSpecDecl(Declaration):
@@ -473,6 +473,8 @@ class Throw(Node):
 class NoExcept(Node):
     attrs = ("repr",)
 
+class NoThrow(Node):
+    attrs = ()
 
 class ClassTemplateDecl(Declaration):
     attrs = ("subnodes",)


### PR DESCRIPTION
This led to harmonization of exception specification across the different types of function decl.

This was a difficult one has there is no information about explicit or implicit specification, event at the IR level. Rely on source then.