### PR TITLE
c++ syntax - `using namespace xxx;`

### DIFF
--- a/asdl/lang/cpp/test/using_namespace.hpp
+++ b/asdl/lang/cpp/test/using_namespace.hpp
@@ -1,0 +1,41 @@
+
+namespace A {}
+
+// names in A are brought in the current scope
+using namespace A;
+
+// must work whatever the scope (except class/struct scope):
+namespace X
+{
+    // in another namespace's scope
+    using namespace A;
+}
+
+namespace Y
+{
+    // in a function scope
+    void function()
+    {
+        using namespace A;
+    }
+}
+
+// sub-namespace access
+// FIXME:
+// namespace A { namespace B { } }
+// namespace D
+// {
+//     // in another namespace's scope
+//     using namespace A::B;
+//     using namespace ::A::B;
+// }
+
+// namespace W
+// {
+//     // in a function scope
+//     void function()
+//     {
+//         using namespace A::B;
+//         using namespace ::A::B;
+//     }
+// }

--- a/cpplang/parser.py
+++ b/cpplang/parser.py
@@ -1158,8 +1158,8 @@ class Parser(object):
     @parse_debug
     def parse_UsingDirectiveDecl(self, node) -> tree.UsingDirectiveDecl:
         assert node['kind'] == "UsingDirectiveDecl"
-        name = (self.get_node_source_code(node).replace('using namespace','').strip()
-                + node['nominatedNamespace']['name'])
+        name = node['nominatedNamespace']['name']
+        assert name
         return tree.UsingDirectiveDecl(name=name)
 
     @parse_debug


### PR DESCRIPTION
I was suspicious of my test passing without modifications at first, but it looks like `using namespace` was already supported. However, recent fixes in `main` showed an issue in the parsing so in addition to add a test I also fixed it (kind of reverting to a previous version of the same line, if I read the history correctly).
