### PR TITLE
c++ - support for enum object definition

### DIFF
--- a/asdl/lang/cpp/cppastor/code_gen.py
+++ b/asdl/lang/cpp/cppastor/code_gen.py
@@ -606,6 +606,9 @@ class SourceGenerator(ExplicitNodeVisitor):
         if isinstance(current_type, tree.DecltypeType):
             return "decltype({}) {}".format(current_type.repr, current_expr)
 
+        if isinstance(current_type, tree.EnumType):
+            return "{} {}".format(current_type.name, current_expr)
+
         raise NotImplementedError(current_type)
 
     def visit_TypedefDecl(self, node: tree.TypedefDecl):

--- a/asdl/lang/cpp/test/enum.hpp
+++ b/asdl/lang/cpp/test/enum.hpp
@@ -23,6 +23,10 @@ enum renamed {
   Some
 };
 
+// Usage
+renamed xxx;
+renamed yyy = Some;
+
 // Note: the following definitions will not result in exactly the same code generated,
 // they will look like an enum definition followed by an object declaratoin of that enum's type.
 // TODO: support for types definition in object definitions, maybe by checking `TagType::isBeingDefined()`?

--- a/asdl/lang/cpp/test/enum.hpp
+++ b/asdl/lang/cpp/test/enum.hpp
@@ -22,3 +22,18 @@ enum named {
 enum renamed {
   Some
 };
+
+// Note: the following definitions will not result in exactly the same code generated,
+// they will look like an enum definition followed by an object declaratoin of that enum's type.
+// TODO: support for types definition in object definitions, maybe by checking `TagType::isBeingDefined()`?
+// FIXME: commented examples below because the output is equivalent but not the same.
+
+// enum {
+//   x, y, z,
+// } object;
+
+
+// enum with_name {
+//   u, v, w,
+// } object_with_typed_name;
+


### PR DESCRIPTION
Discussed with @serge-sans-paille , unless we find a way to detect when a type definition is part of an object definition, we can't activate this kind of tests. I suspect `TagType::isBeingDefined()` in clang AST to be the information we need, but I don't know how to expose it to python (or to access it if it's already exposed).

I also spotted the cases where objects are of enum type not being tested and handled and I attempted to fix it here. Not sure if it's the correct way to do it, you'll tell me :)