### PR TITLE
c++ - support `using x::y` to import names in scopes

### DIFF
--- a/asdl/lang/cpp/cppastor/code_gen.py
+++ b/asdl/lang/cpp/cppastor/code_gen.py
@@ -527,7 +527,7 @@ class SourceGenerator(ExplicitNodeVisitor):
                     self.write(" = ", node.init)
 
     def visit_ExprStmt(self, node: tree.ExprStmt):
-        self.write(node.expr, ";")
+        self.write(node.expr, ";\n")
 
     def visit_AttributedStmt(self, node: tree.AttributedStmt):
         self.space_list(node.attributes, trailing=True)

--- a/asdl/lang/cpp/test/using_name_import.hpp
+++ b/asdl/lang/cpp/test/using_name_import.hpp
@@ -1,0 +1,87 @@
+// tests for usage of `using` to import names from namespaces
+// FIXME: using types is not supported yet
+struct X{};
+
+namespace A
+{
+    int object = 0;
+    struct Type{};
+    void function(int) {}
+    void function(X) {}
+    void function(Type) {}
+
+    namespace B
+    {
+        int object = 0;
+        struct Type{};
+        void function(int) {}
+        void function(X) {}
+        void function(Type) {}
+    }
+}
+
+// import specific names from namespace
+void function_specific_names()
+{
+    // from relative namespace
+    {
+        using A::object;
+        using A::function;
+        // using A::Type;
+        function(object);
+        function(X());
+        // function(Type{});
+    }
+
+    // from absolute namespace
+    {
+        using ::A::object;
+        using ::A::function;
+        // using ::A::Type;
+        function(object);
+        function(X());
+        // function(Type{});
+    }
+
+    // from named sub-namespace
+    {
+        using A::B::object;
+        using A::B::function;
+        // using A::B::Type;
+        function(object);
+        function(X());
+        // function(Type{});
+    }
+
+    // from absolute named sub-namespace
+    {
+        using ::A::B::object;
+        using ::A::B::function;
+        // using ::A::B::Type;
+        function(object);
+        function(X());
+        // function(Type{});
+    }
+}
+
+// import names from parent type into current type interface/scope
+class TypeA
+{
+protected:
+    struct Type {};
+    TypeA(int) {}
+    TypeA(X) {}
+    void function() {}
+    void function(X) {}
+    void function(Type) {}
+    int member_data; // FIXME: add `= 0` once CXXDefaultInitExpr is supported
+};
+
+class TypeB : private TypeA
+{
+public:
+    // using TypeA::TypeA;         // import multiple constructors, make them public FIXME: this needs to work
+    using TypeA::function;      // import multiple functions, make them public
+    using TypeA::member_data;   // make data member public
+    // using TypeA::Type;          // make inner-type public FIXME: this needs to work
+};

--- a/cpplang/tree.py
+++ b/cpplang/tree.py
@@ -787,9 +787,6 @@ class ExpressionStmt(Statement):
 class GCCAsmStmt(Statement):
     attrs = ("string", "output_operands", "input_operands", "clobbers", "labels",)
 
-class ExprWithCleanups(Node):
-    attrs = ("expr",)
-
 class ConstrainedExpression(Node):
     attrs = ("expr", "constraint")
 
@@ -983,6 +980,11 @@ class UnaryExprOrTypeTraitExpr(Expression):
 
 class ImplicitCastExpr(Expression):
     attrs = ("type", "expr",)
+
+
+class ExprWithCleanups(Expression):
+    attrs = ("expr",)
+
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Not ready yet, there are many missing parts, wip.