### PR TITLE
cpp - improved `static_cast` and `const_cast` support

### DIFF
--- a/asdl/lang/cpp/cpp_asdl.simplified.txt
+++ b/asdl/lang/cpp/cpp_asdl.simplified.txt
@@ -75,7 +75,8 @@ expression = AddrLabelExpr(identifier name)
            | CXXNullPtrLiteralExpr
            | CXXOperatorCallExpr(expression left, expression op, expression right)
            | CXXReinterpretCastExpr(type type, expression expr)
-           | CXXStaticCastExpr(type type, expression expr)
+           | CXXStaticCastExpr(type type, expression expr, constant value_category)
+           | CXXConstCastExpr(type type, expression expr, constant value_category)
            | CXXStdInitializerListExpr(expression* subnodes)
            | CXXTemporaryObjectExpr(type type, expression* args)
            | CXXThisExpr

--- a/asdl/lang/cpp/cppastor/code_gen.py
+++ b/asdl/lang/cpp/cppastor/code_gen.py
@@ -1087,7 +1087,16 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.write(node.type, "(", node.expr, ")")
 
     def visit_CXXStaticCastExpr(self, node: tree.CXXStaticCastExpr):
-        self.write("static_cast<", node.type, ">(", node.expr, ")")
+        self.write("static_cast<", node.type)
+        if node.value_category == "lvalue":
+            self.write("&")
+        self.write(">(", node.expr, ")")
+
+    def visit_CXXConstCastExpr(self, node: tree.CXXConstCastExpr):
+        self.write("const_cast<", node.type)
+        if node.value_category == "lvalue":
+            self.write("&")
+        self.write(">(", node.expr, ")")
 
     def visit_CXXReinterpretCastExpr(self, node: tree.CXXReinterpretCastExpr):
         self.write("reinterpret_cast<", node.type, ">(", node.expr, ")")

--- a/asdl/lang/cpp/test/cast.hpp
+++ b/asdl/lang/cpp/test/cast.hpp
@@ -13,9 +13,33 @@ void foo() {
 
 void bar() {
   int(1);
+
+  // value static_cast
+  int a;
   static_cast<float>(1);
+  static_cast<float>(a);
+
+  // pointer/inheritance static_cast
+  struct U{};
+  struct V : U{};
+  V v;
+  U* ptr_u = static_cast<U*>(&v);
+  V* ptr_v = static_cast<V*>(ptr_u);
+  U& ref_u = static_cast<U&>(v);
+  V& ref_v = static_cast<V&>(ref_u);
+
+  // reinterpret_cast
   unsigned long i;
   reinterpret_cast<long *>(&i);
+  int buffer[10];
+  reinterpret_cast<char*>(&buffer);
+
+  // const_cast reference or pointer
+  int x = 0;
+  const int& x_const = const_cast<const int&>(x);
+  int& x_not_const = const_cast<int&>(x_const);
+  const int* ptr_x_const = const_cast<const int*>(&x);
+  int* ptr_x = const_cast<int*>(ptr_x_const);
 }
 
 

--- a/cpplang/parser.py
+++ b/cpplang/parser.py
@@ -2049,7 +2049,16 @@ class Parser(object):
         assert node['kind'] == "CXXStaticCastExpr"
         type_ = self.parse_node(self.type_informations[node['id']])
         expr, = self.parse_subnodes(node)
-        return tree.CXXStaticCastExpr(type=type_, expr=expr)
+        value_category = node['valueCategory']
+        return tree.CXXStaticCastExpr(type=type_, expr=expr, value_category=value_category)
+
+    @parse_debug
+    def parse_CXXConstCastExpr(self, node) -> tree.CXXConstCastExpr:
+        assert node['kind'] == "CXXConstCastExpr"
+        type_ = self.parse_node(self.type_informations[node['id']])
+        expr, = self.parse_subnodes(node)
+        value_category = node['valueCategory']
+        return tree.CXXConstCastExpr(type=type_, expr=expr, value_category=value_category)
 
     @parse_debug
     def parse_CXXReinterpretCastExpr(self, node) -> tree.CXXReinterpretCastExpr:

--- a/cpplang/tree.py
+++ b/cpplang/tree.py
@@ -1075,7 +1075,10 @@ class CXXFunctionalCastExpr(Expression):
 
 
 class CXXStaticCastExpr(Expression):
-    attrs = ("type", "expr",)
+    attrs = ("type", "expr", "value_category")
+
+class CXXConstCastExpr(Expression):
+    attrs = ("type", "expr", "value_category")
 
 
 class CXXReinterpretCastExpr(Expression):


### PR DESCRIPTION
`static_assert` was not supporting conversions to references so I fixed that because it was also necessary for `const_cast`
However this shows an issue in how we treat types, we better have a general way to get `T&` as a string when we have a type node. I'll add that separately.