### PR TITLE
c++ - support for member initialization (initializer lists and default member initialization)

### DIFF
--- a/asdl/lang/cpp/cpp_asdl.simplified.txt
+++ b/asdl/lang/cpp/cpp_asdl.simplified.txt
@@ -117,6 +117,7 @@ expression = AddrLabelExpr(identifier name)
            | UnresolvedLookupExpr(identifier name)
            | UserDefinedLiteral(constant suffix, expression expr)
            | VAArgExpr(expression expr, type type)
+           | CXXDefaultInitExpr(expression expr)
 
 parameter = ParmVarDecl(type type, identifier? name, expression? default, attribute* attributes)
 

--- a/asdl/lang/cpp/cppastor/code_gen.py
+++ b/asdl/lang/cpp/cppastor/code_gen.py
@@ -589,6 +589,9 @@ class SourceGenerator(ExplicitNodeVisitor):
         self.write(";")
         self.newline(extra=1)
 
+    def visit_CXXDefaultInitExpr(self, node: tree.CXXDefaultInitExpr):
+        self.write(node.expression)
+
     def visit_type_helper(self, current_expr, current_type):
         if isinstance(current_type, tree.BitIntType):
             return "{}_BitInt({}) {}".format("" if current_type.sign == "signed" else

--- a/asdl/lang/cpp/test/init-member.hpp
+++ b/asdl/lang/cpp/test/init-member.hpp
@@ -1,0 +1,62 @@
+// member initialization in declaration
+
+int new_value();
+
+struct A {};
+A* new_A();
+
+// Pre-c++ 11 way of initializing members
+class with_member_initializer_list
+{
+    int a;
+    int b;
+
+    A* pa;
+    A* pb;
+
+    struct Impl {};
+    Impl* impl;
+    Impl* null;
+
+    with_member_initializer_list()
+        : a(0)
+        , b(0)
+        , pa(new_A())
+        , pb(new A)
+        , impl(new Impl)
+        , null(nullptr)
+    {}
+};
+
+// post-C++11 default member initialization
+// note: this case will not generate `CXXDefaultInitExpr` nodes
+class no_user_defined_constructor
+{
+    int a = 0;
+    int b = new_value();
+
+    A* pa = new_A();
+    A* pb = new A;
+
+    struct Impl {};
+    Impl* impl = new Impl;
+    Impl* null = nullptr;
+};
+
+// note: this case will not generate the same node-tree as without a constructor
+// and will add `CXXDefaultInitExpr` nodes
+class with_user_defined_constructor
+{
+    with_user_defined_constructor() {}
+    with_user_defined_constructor(int value) : a(value), impl(nullptr) {}
+
+    int a = 0;
+    int b = new_value();
+
+    A* pa = new_A();
+    A* pb = new A;
+
+    struct Impl {};
+    Impl* impl = new Impl;
+    Impl* null = nullptr;
+};

--- a/asdl/lang/cpp/test/using_name_import.hpp
+++ b/asdl/lang/cpp/test/using_name_import.hpp
@@ -74,7 +74,7 @@ protected:
     void function() {}
     void function(X) {}
     void function(Type) {}
-    int member_data; // FIXME: add `= 0` once CXXDefaultInitExpr is supported
+    int member_data = 0;
 };
 
 class TypeB : private TypeA

--- a/cpplang/parser.py
+++ b/cpplang/parser.py
@@ -713,6 +713,11 @@ class Parser(object):
             name = anyInit['name']
             args = self.parse_subnodes(node)
 
+            # When the initializer list is not user-defined we need to not write anything.
+            # Only if it have been written explicitly (user-defined) must we take it into account.
+            if not args:
+                return None
+
         baseInit = node.get('baseInit')
         if baseInit:
             name = baseInit["qualType"]
@@ -1817,6 +1822,15 @@ class Parser(object):
         return tree.FieldDecl(name=name, type=var_type, init=init,
                               type_qualifier=type_qualifier,
                               bitwidth=bitwidth, attributes=attributes)
+
+    @parse_debug
+    def parse_CXXDefaultInitExpr(self, node) -> tree.CXXDefaultInitExpr:
+        assert node['kind'] == "CXXDefaultInitExpr"
+        expr = node.get('expression')
+        if expr:
+            return tree.CXXDefaultInitExpr(expr=expr)
+        else:
+            return None
 
     @parse_debug
     def parse_BinaryOperator(self, node) -> tree.BinaryOperator:

--- a/cpplang/tree.py
+++ b/cpplang/tree.py
@@ -618,6 +618,8 @@ class ParmVarDecl(Declaration):
 class FieldDecl(Declaration):
     attrs = ("type", "name", "init", "bitwidth", "attributes", "type_qualifier",)
 
+class CXXDefaultInitExpr(Declaration):
+    attrs = ("expression",)
 
 class ClassTag(Node):
     attrs = ()


### PR DESCRIPTION
For some reason not all usage of member initialization in definitions dont always generate `CXXDefaultInitExpr` nodes which was not yet supported, for example clang does generate these nodes when there is a user-defined constructor in addition to default member initializers. This PR is about supporting `CXXDefaultInitExpr`.